### PR TITLE
Handle AlphaVantage's current rate limit responses

### DIFF
--- a/src/dialog/settings/currency.tsx
+++ b/src/dialog/settings/currency.tsx
@@ -66,8 +66,8 @@ export const DialogCurrencyContents: React.FC = () => {
                 .
             </Typography>
             <Typography variant="caption" sx={{ marginTop: 8, color: Greys[700], fontStyle: "italic" }}>
-                Note that free AlphaVantage keys are limited to 5 requests per minute, and 500 requests per day: if
-                necessary, TopHat batches requests and waits for capacity.
+                Note that free AlphaVantage keys are limited to one request per second, and 25 requests per day: if
+                necessary, TopHat spaces out requests and waits for capacity.
             </Typography>
             <SettingsDialogDivider />
             <SettingsDialogContents>

--- a/src/state/logic/currencies.test.ts
+++ b/src/state/logic/currencies.test.ts
@@ -1,0 +1,83 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { formatDate, getCurrentMonth } from "../shared/values";
+import { getCurrencyRates } from "./currencies";
+
+const MONTH = getCurrentMonth();
+
+const RATES = { "Time Series FX (Monthly)": { [formatDate(MONTH)]: { "4. close": "0.72130" } } };
+const PARSED_RATES = [{ month: formatDate(MONTH), value: 0.72 }];
+const RATE_LIMITED = {
+    Information:
+        "Thank you for using Alpha Vantage! Please consider spreading out your free API requests more sparingly " +
+        "(1 request per second). You may subscribe to any of the premium plans at " +
+        "https://www.alphavantage.co/premium/ to lift the free key rate limit (25 requests per day), raise the " +
+        "per-second burst limit, and instantly unlock all premium endpoints",
+};
+
+const respondWith = (...bodies: object[]) => {
+    const fetchMock = vi.fn(async () => ({
+        json: async () => bodies[Math.min(fetchMock.mock.calls.length - 1, bodies.length - 1)],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+};
+
+// Each test uses its own ticker, since successful pulls are cached in localStorage for the day
+let counter = 0;
+const uniqueTicker = () => `TICKER${counter++}`;
+
+beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+});
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+test("Rate limited requests are retried rather than reported as failures", async () => {
+    const fetchMock = respondWith(RATE_LIMITED, RATES);
+
+    const rates = getCurrencyRates("currency", uniqueTicker(), "token");
+    await vi.advanceTimersByTimeAsync(10 * 1000);
+
+    expect(await rates).toEqual(PARSED_RATES);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+test("Persistent rate limiting eventually fails, rather than retrying forever", async () => {
+    const fetchMock = respondWith(RATE_LIMITED);
+
+    const rates = getCurrencyRates("currency", uniqueTicker(), "token");
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+
+    expect(await rates).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+});
+
+test("Requests are spaced out, so that they do not rate limit each other", async () => {
+    const fetchMock = respondWith(RATES);
+
+    const rates = [uniqueTicker(), uniqueTicker(), uniqueTicker()].map((ticker) =>
+        getCurrencyRates("currency", ticker, "token")
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(await Promise.all(rates)).toEqual(rates.map(() => PARSED_RATES));
+});
+
+test("Rejected requests are not retried", async () => {
+    const fetchMock = respondWith({ "Error Message": "the parameter apikey is invalid or missing." });
+
+    const rates = getCurrencyRates("currency", uniqueTicker(), "token");
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+
+    expect(await rates).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+});

--- a/src/state/logic/currencies.ts
+++ b/src/state/logic/currencies.ts
@@ -9,17 +9,46 @@ import { CURRENCY_NOTIFICATION_ID } from "./notifications/types";
 
 const CACHE = new DailyCache<CurrencyExchangeRate[]>("CURRENCY_RATE_CACHE");
 
-const getFromAPI = async (query: string, token: string, key: string): Promise<CurrencyExchangeRate[] | undefined> => {
-    const request = await fetch(`https://www.alphavantage.co/query?function=${query}&apikey=${token}`);
-    const response = await request.json();
+const sleep = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+// Free AlphaVantage keys are limited to one request a second, so requests are spaced out rather
+// than fired off in parallel: several synced currencies would otherwise rate limit each other.
+const REQUEST_SPACING_MILLISECONDS = 1000;
+let queue: Promise<unknown> = Promise.resolve();
+// The response is raw JSON from the API, and is checked for the expected shape below
+const queueAPIRequest = (query: string, token: string): Promise<Record<string, any>> => {
+    const response = queue
+        .then(() => fetch(`https://www.alphavantage.co/query?function=${query}&apikey=${token}`))
+        .then((request) => request.json());
+
+    const spacing = () => sleep(REQUEST_SPACING_MILLISECONDS);
+    queue = response.then(spacing, spacing);
+
+    return response;
+};
+
+// A rate limited request still comes back as a 200, with a body holding nothing but an explanation:
+// under "Note" in older versions of the API and under "Information" since. Rather than match on
+// that wording, which has changed before now, anything which is neither the requested data nor an
+// explicit error is taken to be a rate limit and retried after a pause.
+const RATE_LIMIT_RETRY_DELAYS = [1000, 2000, 4000];
+
+const getFromAPI = async (
+    query: string,
+    token: string,
+    key: string,
+    retries: number[] = RATE_LIMIT_RETRY_DELAYS
+): Promise<CurrencyExchangeRate[] | undefined> => {
+    const response = await queueAPIRequest(query, token);
     const data = response[key];
 
     if (data === undefined) {
-        if ((response?.Note as string | undefined)?.endsWith("target a higher API call frequency.")) {
-            // Standard AlphaVantage rate limit is 5 per second - this retries in case of bottlenecks
-            return new Promise((resolve) => setTimeout(() => resolve(getFromAPI(query, token, key)), 60 * 1000));
-        }
-        return undefined;
+        // The daily quota also arrives as a rate limit, so retries are capped and the caller is
+        // eventually told the sync has failed
+        if (response["Error Message"] !== undefined || retries.length === 0) return undefined;
+
+        await sleep(retries[0]);
+        return getFromAPI(query, token, key, retries.slice(1));
     }
 
     const history = toPairs(data).map(([month, values]) => [month, Number((values as any)["4. close"])]) as [


### PR DESCRIPTION
Currency syncs fire one request per synced currency in parallel, and free AlphaVantage keys allow only one request a second, so all but the first come back rate limited. Those responses used to carry a "Note" field, which was detected and retried, but they now carry "Information" instead - so they fell through to being read as a failure, and the "Currency Sync Failed" notification appeared until enough rates had been cached to squeeze the sync under the limit.

Requests are now spaced out rather than fired in parallel, so the limit is not tripped in the first place. Rate limits are recognised by the absence of data rather than by the wording of the message, which has changed before, and are retried a bounded number of times so that the daily quota still surfaces as a failed sync rather than retrying forever.