### PR TITLE
Tell an empty database apart from one that can't be read

### DIFF
--- a/src/app/storage.tsx
+++ b/src/app/storage.tsx
@@ -1,0 +1,80 @@
+import styled from "@emotion/styled";
+import { ReportProblem } from "@mui/icons-material";
+import { Button, Typography } from "@mui/material";
+import React, { useCallback, useState } from "react";
+import { NonIdealState } from "../components/display/NonIdealState";
+import { deleteDatabase, downloadRescuedDatabaseContents } from "../state/logic/storage/rescue";
+import { StorageState } from "../state/logic/storage/types";
+import { Greys } from "../styles/colours";
+
+/**
+ * Shown in place of the app when there is data in the browser which TopHat can't read: the
+ * alternative is the tutorial state, which looks exactly like a new install and invites the user to
+ * start typing over data that is still there.
+ */
+export const StorageErrorPage: React.FC<{ state: StorageState & { type: "unreadable" } }> = ({ state }) => {
+    const [confirming, setConfirming] = useState(false);
+    const [deletionError, setDeletionError] = useState<string | null>(null);
+
+    const deleteData = useCallback(() => {
+        if (!confirming) return setConfirming(true);
+
+        deleteDatabase()
+            .then(() => window.location.reload())
+            .catch((error: Error) => setDeletionError(error.message));
+    }, [confirming]);
+
+    return (
+        <ContainerBox>
+            <NonIdealState
+                intent="danger"
+                icon={ReportProblem}
+                title="Data Could Not Be Read"
+                subtitle={
+                    <ContentsBox>
+                        <Typography variant="body2">
+                            TopHat has found saved data in this browser, but can't open it - perhaps because it was
+                            written by a newer version of the app. Nothing has been changed or deleted, and nothing will
+                            be saved until it can be read again.
+                        </Typography>
+                        <Typography variant="body2" sx={ErrorSx}>
+                            {deletionError ?? state.error}
+                        </Typography>
+                        <ActionsBox>
+                            <Button variant="outlined" onClick={reload}>
+                                Try Again
+                            </Button>
+                            {state.rescuedRows ? (
+                                <Button variant="outlined" onClick={downloadRescuedDatabaseContents}>
+                                    Download Debug File
+                                </Button>
+                            ) : undefined}
+                            <Button variant="outlined" color="error" onClick={deleteData}>
+                                {confirming ? "Click Again to Confirm" : "Delete Data and Restart"}
+                            </Button>
+                        </ActionsBox>
+                    </ContentsBox>
+                }
+            />
+        </ContainerBox>
+    );
+};
+
+const reload = () => window.location.reload();
+
+const ContainerBox = styled("div")({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "100vh",
+    width: "100vw",
+});
+const ContentsBox = styled("div")({ maxWidth: 520, marginTop: 20, textAlign: "center" });
+const ActionsBox = styled("div")({
+    display: "flex",
+    justifyContent: "center",
+    gap: 10,
+    marginTop: 25,
+    "& > button": { whiteSpace: "nowrap" },
+});
+const ErrorSx = { fontStyle: "italic", color: Greys[700], margin: "15px 0 0 0" } as const;

--- a/src/app/tutorial.tsx
+++ b/src/app/tutorial.tsx
@@ -7,6 +7,7 @@ import { NonIdealState } from "../components/display/NonIdealState";
 import { TopHatDispatch } from "../state";
 import { DataSlice } from "../state/data";
 import { useUserData } from "../state/data/hooks";
+import { useSelector } from "../state/shared/hooks";
 import { importJSONData } from "../state/logic/import";
 import { initialiseDemoData } from "../state/logic/startup";
 import { AppColours, WHITE } from "../styles/colours";
@@ -15,6 +16,7 @@ export const MIN_WIDTH_FOR_APPLICATION = 1200;
 
 export const TopHatTutorial: React.FC = () => {
     const open = useUserData((user) => user.tutorial);
+    const storage = useSelector((state) => state.app.storage);
     const [loading, setLoading] = useState(false);
     useEffect(() => {
         if (open) setLoading(false);
@@ -33,6 +35,9 @@ export const TopHatTutorial: React.FC = () => {
     }, [setWidth]);
     const [widthDismissed, setWidthDismissed] = useState(false);
     const dismissWidth = useCallback(() => setWidthDismissed(true), []);
+
+    // The tutorial state is a placeholder when saved data couldn't be read, not an invitation
+    if (storage.type === "unreadable") return null;
 
     if (width < MIN_WIDTH_FOR_APPLICATION && !widthDismissed)
         return (

--- a/src/app/view.tsx
+++ b/src/app/view.tsx
@@ -14,10 +14,12 @@ import { useSelector } from "../state/shared/hooks";
 import { APP_BACKGROUND_COLOUR } from "../styles/theme";
 import { NavBar } from "./navbar";
 import { useSetAlert } from "./popups";
+import { StorageErrorPage } from "./storage";
 import { MIN_WIDTH_FOR_APPLICATION } from "./tutorial";
 
 export const View: React.FC = () => {
     const page = useSelector((state) => state.app.page.id);
+    const storage = useSelector((state) => state.app.storage);
     const setAlert = useSetAlert();
     useEffect(
         () =>
@@ -33,6 +35,8 @@ export const View: React.FC = () => {
             ),
         [setAlert]
     );
+
+    if (storage.type === "unreadable") return <StorageErrorPage state={storage} />;
 
     return (
         <AppContainerBox>

--- a/src/state/app/index.ts
+++ b/src/state/app/index.ts
@@ -1,5 +1,6 @@
 import { AnyAction, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { get, trimEnd } from "lodash";
+import { StorageState } from "../logic/storage/types";
 import { ID } from "../shared/values";
 import { DefaultDialogs, DefaultPages, DialogState } from "./defaults";
 import {
@@ -16,6 +17,8 @@ export type { DialogState } from "./defaults";
 interface AppState {
     dialog: DialogState;
     page: PageStateType;
+    // How the attempt to load saved data went, and left alone by everything else in here
+    storage: StorageState;
 }
 
 export const BASE_PATHNAME = "/TopHat";
@@ -32,7 +35,7 @@ const getDefaultPageState = (page: PageStateType | null) => ({
     page: page || DefaultPages["summary"],
 });
 
-export const getAppStateFromPagePath = (location: Location): AppState => {
+export const getAppStateFromPagePath = (location: Location): Omit<AppState, "storage"> => {
     const [_, page, id] = trimEnd(location.pathname, "#").substring(BASE_PATHNAME.length).split("/");
 
     if (page === "dropbox")
@@ -48,9 +51,11 @@ export const getAppStateFromPagePath = (location: Location): AppState => {
     return getDefaultPageState(get(DefaultPages, page, DefaultPages.summary));
 };
 
+const initialState: AppState = { ...getAppStateFromPagePath(window.location), storage: { type: "loading" } };
+
 export const AppSlice = createSlice({
     name: "app",
-    initialState: getAppStateFromPagePath(window.location),
+    initialState,
     reducers: {
         setPage: (state, { payload }: PayloadAction<PageStateType["id"]>) => {
             state.page = DefaultPages[payload];
@@ -58,7 +63,7 @@ export const AppSlice = createSlice({
         setPageState: (state, { payload: page }: PayloadAction<PageStateType>) => {
             state.page = page;
         },
-        setPageStateFromPath: () => getAppStateFromPagePath(window.location),
+        setPageStateFromPath: (state) => ({ ...getAppStateFromPagePath(window.location), storage: state.storage }),
         setAccountsPagePartial: (state, { payload }: PayloadAction<Partial<AccountsPageState>>) => {
             state.page = {
                 ...(state.page.id === "accounts" ? state.page : DefaultPages["accounts"]),
@@ -118,10 +123,14 @@ export const AppSlice = createSlice({
         setDialogPartial: (state, { payload }: PayloadAction<Partial<DialogState>>) => {
             state.dialog = { ...state.dialog, ...payload };
         },
-        closeDialogAndGoToPage: (_, { payload: page }: PayloadAction<PageStateType>) => ({
+        closeDialogAndGoToPage: (state, { payload: page }: PayloadAction<PageStateType>) => ({
             dialog: DefaultDialogs,
             page,
+            storage: state.storage,
         }),
+        setStorageState: (state, { payload }: PayloadAction<StorageState>) => {
+            state.storage = payload;
+        },
     },
 });
 const oldReducer = AppSlice.reducer; // Separate assignment to prevent infinite recursion

--- a/src/state/logic/startup.ts
+++ b/src/state/logic/startup.ts
@@ -29,10 +29,19 @@ export const initialiseAndGetDBConnection = async () => {
     window.onpopstate = () => TopHatDispatch(AppSlice.actions.setPageStateFromPath());
 
     // Set up IDB, if present
-    const { db, loadedStateFromIDB } = await setupIDBConnectionAndLoadData(debug);
+    const { db, storage } = await setupIDBConnectionAndLoadData(debug);
+    TopHatDispatch(AppSlice.actions.setStorageState(storage));
+
+    // Debug variables
+    (window as any).getDebugVariablesAsync = getDebugVariablesAsync(db);
+    if (debug) Object.assign(window, await getDebugVariablesAsync(db)());
+
+    // Saved data that can't be read leaves the app on a recovery screen, so nothing else is started
+    // up: none of it would be saved, and some of it would write over the data that is still there
+    if (storage.type === "unreadable") return;
 
     // If we're in a dropbox redirect loop, we don't want the initial empty state and popup -> silently set up demo
-    if (!loadedStateFromIDB && maybeDropboxCode) await initialiseDemoData();
+    if (storage.type !== "loaded" && maybeDropboxCode) await initialiseDemoData();
 
     // Add notification hook to data updates
     initialiseNotificationUpdateHook();
@@ -49,10 +58,6 @@ export const initialiseAndGetDBConnection = async () => {
 
     // Update caches to latest month
     TopHatDispatch(DataSlice.actions.updateTransactionSummaryStartDates());
-
-    // Debug variables
-    (window as any).getDebugVariablesAsync = getDebugVariablesAsync(db);
-    if (debug) Object.assign(window, await getDebugVariablesAsync(db)());
 };
 
 const initialiseMaybeDropboxSyncFromRedux = () =>

--- a/src/state/logic/storage/database.ts
+++ b/src/state/logic/storage/database.ts
@@ -14,6 +14,8 @@ import {
 } from "../../data/types";
 import { ID } from "../../shared/values";
 
+export const DATABASE_NAME = "TopHatDatabase";
+
 // This class is so Typescript understands the shape of the DB connection
 export class TopHatDexie extends Dexie {
     user: Dexie.Table<User, ID>;
@@ -28,7 +30,7 @@ export class TopHatDexie extends Dexie {
     patches: Dexie.Table<PatchGroup, ID>;
 
     constructor(options?: DexieOptions) {
-        super("TopHatDatabase", options);
+        super(DATABASE_NAME, options);
         this.version(2).stores({
             user: "id",
             account: "id",

--- a/src/state/logic/storage/index.test.ts
+++ b/src/state/logic/storage/index.test.ts
@@ -7,12 +7,13 @@
  * @vitest-environment jsdom
  */
 
-import { omit } from "lodash-es";
+import { omit, sum } from "lodash-es";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { DataState, ListDataState } from "../../data";
 import { getCurrentMonthString, TransactionHistory } from "../../shared/values";
 import {
     Coffee,
+    CurrentSchema,
     DataKeys,
     deleteDatabase,
     getMonthsSince,
@@ -64,7 +65,12 @@ const bootTopHat = async () => {
 
     await initialiseAndGetDBConnection();
 
-    return { dispatch: TopHatDispatch, actions: DataSlice.actions, data: () => TopHatStore.getState().data };
+    return {
+        dispatch: TopHatDispatch,
+        actions: DataSlice.actions,
+        data: () => TopHatStore.getState().data,
+        storage: () => TopHatStore.getState().app.storage,
+    };
 };
 
 /** Redux state as sorted lists, so that it can be compared against the database or the fixtures */
@@ -83,7 +89,9 @@ afterEach(async () => {
 
 describe("Loading and saving", () => {
     test("starts in the tutorial state, and saves nothing, when there is no database", async () => {
-        const { data } = await bootTopHat();
+        const { data, storage } = await bootTopHat();
+
+        expect(storage()).toEqual({ type: "empty" });
 
         expect(data().user.entities[0]!.tutorial).toBe(true);
         expect(data().account.ids).toEqual([]);
@@ -110,8 +118,9 @@ describe("Loading and saving", () => {
     test("loads saved data", async () => {
         await writeToDatabase(getSavedData());
 
-        const { data } = await bootTopHat();
+        const { data, storage } = await bootTopHat();
 
+        expect(storage()).toEqual({ type: "loaded" });
         expect(data().user.entities[0]!.tutorial).toBe(false);
         expect(asLists(data())).toEqual(sortLists(getSavedData()));
     });
@@ -164,6 +173,24 @@ describe("Loading and saving", () => {
         dispatch(actions.updateUserPartial({ alphavantage: "key" }));
         await waitFor(async () => expect(await readFromDatabase()).toEqual(asLists(data())));
         expect((await readFromDatabase()).patches.length).toBeGreaterThan(0);
+    });
+
+    test("keeps data that it cannot read, rather than starting over on top of it", async () => {
+        // A database written by a later version of the app, which this version has no schema for
+        await writeToDatabase(getSavedData(), { ...CurrentSchema, version: CurrentSchema.version + 10 });
+
+        const { data, dispatch, actions, storage } = await bootTopHat();
+
+        const rows = sum(Object.values(getSavedData()).map(({ length }) => length));
+        expect(storage()).toEqual({ type: "unreadable", error: expect.any(String), rescuedRows: rows });
+
+        // The app is in the same state it would start a new install in, but nothing is written
+        expect(data().user.entities[0]!.tutorial).toBe(true);
+        expect(data().transaction.ids).toEqual([]);
+
+        dispatch(actions.updateUserPartial({ tutorial: false }));
+        await pause(25);
+        expect(await readFromDatabase()).toEqual(sortLists(getSavedData()));
     });
 
     test("loads every field of data saved months ago", async () => {

--- a/src/state/logic/storage/index.ts
+++ b/src/state/logic/storage/index.ts
@@ -4,41 +4,60 @@ import { uniq } from "lodash-es";
 import { TopHatDispatch, TopHatStore } from "../..";
 import { zipObject } from "../../../shared/data";
 import { DataSlice, ListDataState, subscribeToDataUpdates } from "../../data";
-import { DataKeys, DataState, StubUserID } from "../../data/types";
+import { DataKeys, DataState, StubUserID, User } from "../../data/types";
 import { ID } from "../../shared/values";
 import { setIDBConnectionExists } from "../notifications/variants/idb";
-import { TopHatDexie } from "./database";
+import { DATABASE_NAME, TopHatDexie } from "./database";
 import { handleMigrationsAndUpdates } from "./migrations";
+import { rescueDatabaseContents } from "./rescue";
+import { StorageState } from "./types";
 
 export const setupIDBConnectionAndLoadData = async (debug: boolean) => {
     // Set up IDB, if present
-    let db = new TopHatDexie();
-    let loadedStateFromIDB = false;
-    await db.user
-        .get(StubUserID)
-        .then(async (user) => {
-            if (user) {
-                // IDB contains existing TopHat state
-                if (debug) console.log("Hydrating store from IndexedDB...");
-                await hydrateReduxFromIDB(db);
-                handleMigrationsAndUpdates(user.generation);
-                loadedStateFromIDB = true;
-            }
+    const db = new TopHatDexie();
 
-            const uuid = "" + new Date().getTime() + Math.random();
-            initialiseIDBSyncFromRedux(db, uuid);
-            initialiseIDBListener(db, uuid, debug);
-            setIDBConnectionExists(true);
-        })
-        .catch(async () => {
-            // TODO: tell "there is no data" apart from "the data could not be read". Both end up
-            // here, and both start the app in its tutorial state, so a read that fails against data
-            // that is really there looks to the user like a brand new install. Storage should only
-            // be written when we know the database is empty, rather than when reading it went wrong.
-            if (debug) console.log("IndexedDB connection failed - bypassing initial load...");
-        });
+    let user: User | undefined;
+    try {
+        user = await db.user.get(StubUserID);
 
-    return { db, loadedStateFromIDB };
+        if (user) {
+            // IDB contains existing TopHat state
+            if (debug) console.log("Hydrating store from IndexedDB...");
+            await hydrateReduxFromIDB(db);
+            handleMigrationsAndUpdates(user.generation);
+        }
+    } catch (error) {
+        return { db, storage: await getStorageFailureState(db, error, debug) };
+    }
+
+    const uuid = "" + new Date().getTime() + Math.random();
+    initialiseIDBSyncFromRedux(db, uuid);
+    initialiseIDBListener(db, uuid, debug);
+    setIDBConnectionExists(true);
+
+    const storage: StorageState = user ? { type: "loaded" } : { type: "empty" };
+    return { db, storage };
+};
+
+/**
+ * Tells "there is no data" apart from "the data could not be read", so that a database which is
+ * really there is never written over by the empty state that a failed read would otherwise leave
+ * the app in. `Dexie.exists` opens the database as it stands, without the schema that TopHat has
+ * just failed to open it with, so it answers whether there is anything there to lose.
+ */
+const getStorageFailureState = async (db: TopHatDexie, error: unknown, debug: boolean): Promise<StorageState> => {
+    const description = error instanceof Error ? error.message : "" + error;
+    if (debug) console.log("Could not load data from IndexedDB: " + description);
+
+    // Dexie says the same thing again on a second line, and only the first is worth showing
+    const message = description.split("\n")[0].trim();
+
+    db.close();
+    setIDBConnectionExists(false);
+    const exists = await Dexie.exists(DATABASE_NAME).catch(() => false);
+    if (!exists) return { type: "unavailable", error: message };
+
+    return { type: "unreadable", error: message, rescuedRows: await rescueDatabaseContents() };
 };
 
 type DBDataTables = keyof Omit<DataState, "transaction"> | "transaction_";

--- a/src/state/logic/storage/rescue.ts
+++ b/src/state/logic/storage/rescue.ts
@@ -1,0 +1,73 @@
+/**
+ * Last-ditch access to a database that TopHat itself can no longer open, used by the recovery
+ * screen shown when saved data can't be read.
+ *
+ * These are written against the raw IndexedDB API rather than Dexie, because the cases they exist
+ * for are the ones where Dexie has already refused: a database written by a newer version of the
+ * app, or one whose contents no longer match the schema.
+ */
+
+import { sum } from "lodash-es";
+import { createAndDownloadFile, zipObject } from "../../../shared/data";
+import { DATABASE_NAME } from "./database";
+
+/** Opens whatever is in the browser without a version, so that no upgrade is attempted */
+const openDatabaseWithoutUpgrade = () =>
+    new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(DATABASE_NAME);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        request.onblocked = () => reject(new Error(BLOCKED_MESSAGE));
+    });
+
+const BLOCKED_MESSAGE = "TopHat is open in another tab, which is still holding on to the data.";
+
+/** Every row still readable out of the database, keyed by table. Dexie's internal tables are left out. */
+const readDatabaseContents = async () => {
+    const db = await openDatabaseWithoutUpgrade();
+    const stores = Array.from(db.objectStoreNames).filter((name) => !name.startsWith("_"));
+
+    const contents = stores.length
+        ? await new Promise<Record<string, unknown[]>>((resolve, reject) => {
+              const tx = db.transaction(stores, "readonly");
+              const requests = stores.map((name) => tx.objectStore(name).getAll());
+
+              tx.oncomplete = () =>
+                  resolve(
+                      zipObject(
+                          stores,
+                          requests.map(({ result }) => result as unknown[])
+                      )
+                  );
+              tx.onerror = () => reject(tx.error);
+              tx.onabort = () => reject(tx.error);
+          })
+        : {};
+
+    db.close();
+    return contents;
+};
+
+let rescued: Record<string, unknown[]> | null = null;
+
+/** Reads what is left of a database that couldn't be loaded, and returns how many rows that was */
+export const rescueDatabaseContents = async () => {
+    rescued = await readDatabaseContents().catch(() => null);
+
+    return rescued ? sum(Object.values(rescued).map(({ length }) => length)) : 0;
+};
+
+/**
+ * The rescued rows, as they are stored rather than as TopHat would use them: this is a debug file
+ * for a database the app has already failed to make sense of, not something it can import.
+ */
+export const downloadRescuedDatabaseContents = () =>
+    createAndDownloadFile("TopHat Debug Data.json", JSON.stringify(rescued));
+
+export const deleteDatabase = () =>
+    new Promise<void>((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(DATABASE_NAME);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+        request.onblocked = () => reject(new Error(BLOCKED_MESSAGE));
+    });

--- a/src/state/logic/storage/types.ts
+++ b/src/state/logic/storage/types.ts
@@ -1,0 +1,12 @@
+/** What became of the attempt to load saved data on boot */
+export type StorageState =
+    /** The app hasn't finished booting, and has yet to look for saved data */
+    | { type: "loading" }
+    /** Data was found in IndexedDB and is now in the store */
+    | { type: "loaded" }
+    /** IndexedDB works and holds no TopHat data, so this is a new install and can be written to */
+    | { type: "empty" }
+    /** IndexedDB can't be used at all, as in private browsing - nothing was lost, but nothing can be saved */
+    | { type: "unavailable"; error: string }
+    /** Data is in the browser but couldn't be read, so it must not be written over */
+    | { type: "unreadable"; error: string; rescuedRows: number };


### PR DESCRIPTION
Both used to end up in the same catch, and so in the tutorial state, which means a failed read against data that is really there looked to the user exactly like a brand new install.

The storage boot now returns a StorageState union, held in the app slice. `Dexie.exists` opens the database as it stands rather than through the schema that has just failed on it, which says whether there is anything there to lose: if there is, the app shows a recovery screen instead of the tutorial, and starts none of the syncs that would otherwise run over data it can't see.

The screen offers a raw dump of whatever rows are still readable, written against the IndexedDB API rather than Dexie so that it works on exactly the databases Dexie refuses. It is a debug file rather than something the app can import, since it comes from data TopHat has already failed to make sense of.